### PR TITLE
Fix invalid escape sequence warning for regexp

### DIFF
--- a/code/backend/decision_backend/baklava/translate/sanitize.py
+++ b/code/backend/decision_backend/baklava/translate/sanitize.py
@@ -20,4 +20,4 @@ def remove_newslines(s: str):
 def remove_unsafe_characters(s: str):
     """Remove any"""
     s_normalized = unicodedata.normalize("NFC", s)
-    return re.sub(f"[^ ${RE_LATIN}${RE_NUMBERS}${RE_GERMAN}${RE_VIETNAMESE}\_]", "", s_normalized)
+    return re.sub(rf"[^ ${RE_LATIN}${RE_NUMBERS}${RE_GERMAN}${RE_VIETNAMESE}\_]", "", s_normalized)


### PR DESCRIPTION
Fixes warning messages:
> <unknown>:23: SyntaxWarning: invalid escape sequence '\_'                                
> ./decision_backend/baklava/translate/sanitize.py:23:76: W605 invalid escape sequence '\_'