### PR TITLE
Fix failing backend tests

### DIFF
--- a/code/backend/decision_backend/baklava/translate/sanitize.py
+++ b/code/backend/decision_backend/baklava/translate/sanitize.py
@@ -20,4 +20,4 @@ def remove_newslines(s: str):
 def remove_unsafe_characters(s: str):
     """Remove any"""
     s_normalized = unicodedata.normalize("NFC", s)
-    return re.sub(rf"[^ ${RE_LATIN}${RE_NUMBERS}${RE_GERMAN}${RE_VIETNAMESE}\_]", "", s_normalized)
+    return re.sub(rf"[^ {RE_LATIN}{RE_NUMBERS}{RE_GERMAN}{RE_VIETNAMESE}\_]", "", s_normalized)

--- a/code/backend/tests/test_api.py
+++ b/code/backend/tests/test_api.py
@@ -22,6 +22,14 @@ def test_user():
     return {"username": "test@test.com", "password": "test"}
 
 
+def _do_login(client, test_user) -> str:
+    response = client.post("/api/auth/jwt/login", data=test_user)
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    assert token is not None
+    return token
+
+
 def test_register(client):
     """Test registering user account."""
     response = client.post("/api/auth/register", json={"email": "test@test.com", "password": "test"})
@@ -35,16 +43,13 @@ def test_register(client):
 
 def test_login(client, test_user):
     """Test logging in with user credentials."""
-    response = client.post("/api/auth/jwt/login", data=test_user)
-    assert response.status_code == 200
-    token = response.json()["access_token"]
+    token = _do_login(client, test_user)
     assert token is not None
-    return token
 
 
 def test_api(client, test_user):
     """Check that the Monte Carlo simulation API route returns some result."""
-    token = test_login(client, test_user)
+    token = _do_login(client, test_user)
 
     example_dir = os.path.join(os.path.dirname(__file__), "fixtures/examples/1_minimal_model")
     with open(os.path.join(example_dir, "graph.json"), "r", encoding="utf8") as f:


### PR DESCRIPTION
Fixes two issues with backend tests:

- the `remove_unsafe_characters` method accidentally uses the Typescript string interpolation syntax, which causes the `$` dollar symbol not to be removed from variable names
- the `test_login` test failed because it did return the token as string, and the test framework doesn't seem to like that